### PR TITLE
Adding one more defaultTypeID in the InsightObjectTypeAttribute class

### DIFF
--- a/jira_insight/insight.py
+++ b/jira_insight/insight.py
@@ -277,6 +277,7 @@ class InsightObjectTypeAttribute:
                 8: "Email",
                 9: "Textarea",
                 10: "Select",
+                11: "IP Address"
             },
             1: "Object",
             2: "User",


### PR DESCRIPTION
Adding "IP Address" as new defaultTypeID.
Supplier's documentation:
https://insight-javadoc.riada.io/insight-javadoc-8.6/insight-rest/#objecttypeattribute__objecttypeid___id__put
and
https://documentation.mindville.com/display/INSSERV/Object+Type+Attributes

Without it you get following error when trying to initialize "Insight" instance:
    self.attribute_type = self.ATTRIBUTE_TYPES[0][default_type_id]
KeyError: 11
